### PR TITLE
Option for JSON output indentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,8 @@ module.exports = function(grunt) {
                   fields: {
                       "test": 11435,
                       "width": 143
-                  }
+                  },
+                  indent: 2
               }
           }
       }

--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ grunt.initConfig({
 Type: `Boolean`
 Default value: `false`
 
-If `true`, properties if `fields` will be added to JSON file(s) regardless of whether the key exists.
+If `true`, properties of `fields` will be added to JSON file(s) regardless of whether the key exists.
 
 #### options.fields
 Type: `Object`
 Default value: `{}`
 
 A key-value pair object of properties to set in JSON file(s).
+
+#### options.indent
+Type: `Number` or `String` or `Null`
+Default value: `4`
+
+For instance the number `2` to use two space characters for indentation or `"\t"` to use tabs. Or `null` to disable pretty-printing.
 
 ### Usage Examples
 
@@ -61,7 +67,8 @@ grunt.initConfig({
       add: true,
       fields: {
         version: "1.1.1"
-      }
+      },
+      indent: "\t"
     },
     files: {
       'dest/default_options': ['src/testing', 'src/123'],

--- a/tasks/modify_json.js
+++ b/tasks/modify_json.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
         // Merge task-specific and/or target-specific options with these defaults.
         var options = this.options({
             fields: {},
-            add: false
+            add: false,
+            indent: 4
         });
 
         // Iterate over all specified file groups.
@@ -49,7 +50,7 @@ module.exports = function(grunt) {
                     return file;
                 })
                 .map(function(file) {
-                    grunt.file.write(file.path, JSON.stringify(file.json, null, 4));
+                    grunt.file.write(file.path, JSON.stringify(file.json, null, options.indent));
                     grunt.log.success('File ' + file.path + ' updated.');
                 });
         });


### PR DESCRIPTION
Changes:
- Added the option to specify or disable pretty-print indentation styles
- Updated test in “Gruntfile.js”
- Updated “README.md”